### PR TITLE
Fix typo in package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buffer-indexof",
-  "description": "find the index of a buffer in a buffe",
+  "description": "find the index of a buffer in a buffer",
   "version": "0.0.2",
   "repository": {
     "url": "git://github.com/soldair/node-buffer-indexof.git"


### PR DESCRIPTION
Your milage may vary while searching for indexOfs in buffes. :water_buffalo: 