### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "tape test/*.js"
   },
   "author": "Ryan Day",
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "chalk": "^1.1.3",


### PR DESCRIPTION
This project includes the license text in the LICENSE file, but it doesn't indicate which license it uses in the package.json metadata, which doesn't play nicely with some tooling.